### PR TITLE
A11Y colour contrast in SVG table bumped up 7.2:1

### DIFF
--- a/svg/index.html
+++ b/svg/index.html
@@ -53,7 +53,7 @@ td.pass {
 	background-color: hsla(184, 100%, 50%, 0.5);
 }
 td.fail {
-	background-color: hsla(336, 100%, 50%, 0.5);
+	background-color: hsla(336, 100%, 65%, 0.5);
 }
 td.unknown {
 	background-color: hsla(0, 0%, 72%, 0.5);


### PR DESCRIPTION
Great presentation! I thought I'd help you out and bump up the contrast on your fail cell!